### PR TITLE
Fixed a bug where the library would fail to parse JSON when the bot is being moved into a supergroup

### DIFF
--- a/TelegramBotNet/DTOs/Chat.cs
+++ b/TelegramBotNet/DTOs/Chat.cs
@@ -4,7 +4,7 @@
     public class Chat
     {
         [JsonProperty(PropertyName = "id")]
-        public int Id { get; set; }
+        public long Id { get; set; }
 
         [JsonProperty(PropertyName = "type")]
         public string Type { get; set; }

--- a/TelegramBotNet/DTOs/Message.cs
+++ b/TelegramBotNet/DTOs/Message.cs
@@ -80,10 +80,12 @@
         [JsonProperty(PropertyName = "channel_chat_created")]
         public bool ChangelChatCreated { get; set; }
 
+        /* Since supergroups were added into Telegram, the migrate_to_chat_id values */
+        /* from moving to supergroups no longer fit inside of an Int32 container. */
         [JsonProperty(PropertyName = "migrate_to_chat_id")]
-        public int MigrateToChatId { get; set; }
+        public long MigrateToChatId { get; set; }
 
         [JsonProperty(PropertyName = "migrate_from_chat_id")]
-        public int MigrateFromChatId { get; set; }
+        public long MigrateFromChatId { get; set; }
     }
 }


### PR DESCRIPTION
Since supergroups were added into Telegram, the migrate_to_chat_id values from moving to supergroups, no longer fit inside of an Int32 container. I fixed that by changing the relevant properties to use Int64.
